### PR TITLE
Customize page control through delegate protocol

### DIFF
--- a/KIImagePager/KIImagePager/KIImagePager.h
+++ b/KIImagePager/KIImagePager/KIImagePager.h
@@ -33,6 +33,7 @@ typedef void(^KIImagePagerImageRequestBlock)(UIImage*image, NSError * error);
 @optional
 - (void) imagePager:(KIImagePager *)imagePager didScrollToIndex:(NSUInteger)index;
 - (void) imagePager:(KIImagePager *)imagePager didSelectImageAtIndex:(NSUInteger)index;
+- (void) imagePager:(KIImagePager *)imagePager customizePageControl:(UIPageControl *)pageControl;
 
 @end
 

--- a/KIImagePager/KIImagePager/KIImagePager.m
+++ b/KIImagePager/KIImagePager/KIImagePager.m
@@ -426,6 +426,10 @@
     }
   }
   [_pageControl setHidden:NO];
+
+    if([_delegate respondsToSelector:@selector(imagePager:customizePageControl:)]) {
+        [_delegate imagePager:self customizePageControl:_pageControl];
+    }
 }
 
 - (void) setPageControlCenter:(CGPoint)pageControlCenter

--- a/KIImagePager/KIViewController.m
+++ b/KIImagePager/KIViewController.m
@@ -73,4 +73,9 @@
     NSLog(@"%s %lu", __PRETTY_FUNCTION__, (unsigned long)index);
 }
 
+- (void)imagePager:(KIImagePager *)imagePager customizePageControl:(UIPageControl *)pageControl
+{
+    NSLog(@"%s", __PRETTY_FUNCTION__);
+}
+
 @end


### PR DESCRIPTION
This adds a delegate protocol method for being able to customize the page control.

For example if you want to resize, move and change the background of the page control.

```
- (void)imagePager:(KIImagePager *)imagePager customizePageControl:(UIPageControl *)pageControl
{
    CGSize size = [pageControl sizeForNumberOfPages:pageControl.numberOfPages];
    pageControl.frame = CGRectMake(pageControl.frame.origin.x, pageControl.frame.origin.y, size.width + 30, size.height);
    pageControl.center = CGPointMake(imagePager.scrollView.frame.size.width / 2, imagePager.scrollView.frame.size.height - 56.0);
    pageControl.backgroundColor = [UIColor colorWithWhite:0.0 alpha:0.35];
}
```
