### PR TITLE
Page control initial postion at the bottom center

### DIFF
--- a/KIImagePager/KIImagePager/KIImagePager.m
+++ b/KIImagePager/KIImagePager/KIImagePager.m
@@ -303,7 +303,7 @@
 #pragma mark - PageControl Initialization
 - (void) initializePageControl
 {
-    CGRect pageControlFrame = CGRectMake(0, 0, _scrollView.frame.size.width, kPageControlHeight);
+    CGRect pageControlFrame = CGRectMake(_scrollView.frame.size.width / 2, _scrollView.frame.size.height, _scrollView.frame.size.width, kPageControlHeight);
     _pageControl = [[UIPageControl alloc] initWithFrame:pageControlFrame];
     _pageControl.center = CGPointMake(_scrollView.frame.size.width / 2, _scrollView.frame.size.height - 12.0);
     _pageControl.userInteractionEnabled = NO;


### PR DESCRIPTION
Change the initial position of the page control to be the bottom center of the scroll view.  This is helpful as the page control is typically located at the bottom and if the page controller is moved via the `imagePager:customizePageControl:` protocol then it will animate up from the bottom instead of from the top (which seems awkward).
